### PR TITLE
Database conflicts upon restart resolved.

### DIFF
--- a/detail.md
+++ b/detail.md
@@ -1,8 +1,8 @@
 # archive-service
 
 1. [Example resources](#examples)
-2. [Submission and retrieval endpoints (REST APIs)](#endpoints).
-3. [Tap service](#tapservice).
+2. [Submission and retrieval endpoints (REST APIs)](#endpoints)
+3. [Tap service](#tapservice)
 
 
 ------------------------------------------------------------------------------------------
@@ -13,7 +13,7 @@ Example resources suitable for **minimal** testing (Mandatory properties only).
 #### Example Simple Observation
 Namespace details must conform with the current vo-dml model used.
 ```xml
-<SimpleObservation xmlns:caom2="http://ivoa.net/dm/models/vo-dml/experiment/caom2"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:caom2.SimpleObservation">
+<SimpleObservation xmlns:caom2="http://ivoa.net/dm/models/vo-dml/experiment/caom2"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation">
     <collection>e-merlin</collection>
     <uri>urn:obs:jbo:20170801:obs1</uri>    //Must be unique
     <intent>science</intent>
@@ -31,7 +31,7 @@ Namespace details must conform with the current vo-dml model used.
 ```
 #### Example Derived Observation
 ```xml
-<DerivedObservation xmlns:caom2="http://ivoa.net/dm/models/vo-dml/experiment/caom2"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:caom2.DerivedObservation">
+<DerivedObservation xmlns:caom2="http://ivoa.net/dm/models/vo-dml/experiment/caom2"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:DerivedObservation">
     <collection>test</collection>
     <uri>urn:obs:jbo:20170801:obs1</uri>
     <intent>science</intent>
@@ -41,7 +41,7 @@ Namespace details must conform with the current vo-dml model used.
 ```
 ------------------------------------------------------------------------------------------
 <a id="endpoints"></a>
-### REST API details  
+### REST API details
 Details of the functionality of the archive-service endpoints.
 
 #### Retrieving observations

--- a/src/main/java/org/uksrc/archive/ObservationResource.java
+++ b/src/main/java/org/uksrc/archive/ObservationResource.java
@@ -11,8 +11,6 @@ import jakarta.transaction.Transactional;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.*;
 import jakarta.xml.bind.JAXBElement;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlElements;
 import org.apache.commons.beanutils.BeanUtils;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;

--- a/src/main/java/org/uksrc/archive/ObservationResource.java
+++ b/src/main/java/org/uksrc/archive/ObservationResource.java
@@ -398,19 +398,23 @@ public class ObservationResource {
      * @return Response containing status code and added observation (if successful)
      */
     private Response submitObservation(Observation observation) {
-        try {
-            if (observation.getUri() != null && findObservation(observation.getUri()) == null) {
-                em.persist(observation);
-                em.flush();
+        if (observation.getUri() == null) {
+            return Responses.errorResponse("Observation.uri must be supplied.");
+        }
 
-                Object specObservation = specialiseObservation(observation);
-                return Response.status(Response.Status.CREATED)
-                        .entity(specObservation)
-                        .build();
-            }
-            else {
-                return Responses.errorResponse("Observation URI " + observation.getUri() + " already exists.");
-            }
+        if (findObservation(observation.getUri()) != null) {
+            return Responses.errorResponse("Observation.uri " + observation.getUri() + " already exists.");
+        }
+
+        try {
+            em.persist(observation);
+            em.flush();
+
+            Object specObservation = specialiseObservation(observation);
+            return Response.status(Response.Status.CREATED)
+                    .entity(specObservation)
+                    .build();
+
         } catch (Exception e) {
             return Responses.errorResponse(e);
         }

--- a/src/main/java/org/uksrc/archive/utils/tools/tap/TapSchemaPopulator.java
+++ b/src/main/java/org/uksrc/archive/utils/tools/tap/TapSchemaPopulator.java
@@ -46,6 +46,12 @@ public class TapSchemaPopulator {
                         .setParameter(1, tableName)
                         .getResultList().isEmpty();
 
+                if (!exists  && !tableName.startsWith("\"")) {
+                    exists = !entityManager.createNativeQuery(checkTableExistsSql)
+                            .setParameter(1, "\"" + tableName + "\"")
+                            .getResultList().isEmpty();
+                }
+
                 if (!exists) {
                     tapSchemaRepository.addTable("public", tableName, "table", "Details of a(n) " + tableName);
 

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,4 +1,4 @@
-CREATE SCHEMA "TAP_SCHEMA";
+CREATE SCHEMA IF NOT EXISTS "TAP_SCHEMA";
 
 /*
  Required structure for TAP 1.0
@@ -14,60 +14,94 @@ CREATE SCHEMA "TAP_SCHEMA";
  tap.properties (full Vollt code) suggests this is now redundant and must manually be set in tap.properties
  (removing the ability to dynamically add as with the other properties unfortunately).
  */
-CREATE TABLE "TAP_SCHEMA"."schemas" ("schema_name" VARCHAR, "description" VARCHAR, "utype" VARCHAR, "schema_index" INTEGER, "dbname" VARCHAR, PRIMARY KEY("schema_name"));
-CREATE TABLE "TAP_SCHEMA"."tables" ("schema_name" VARCHAR, "table_name" VARCHAR, "table_type" VARCHAR, "description" VARCHAR, "utype" VARCHAR, "dbname" VARCHAR, "table_index" INTEGER, PRIMARY KEY("table_name"));
-CREATE TABLE "TAP_SCHEMA"."columns" ("table_name" VARCHAR, "column_name" VARCHAR, "description" VARCHAR, "unit" VARCHAR, "ucd" VARCHAR, "utype" VARCHAR, "xtype" VARCHAR, "datatype" VARCHAR, "size" INTEGER, "arraysize" VARCHAR, "principal" SMALLINT, "indexed" SMALLINT, "std" SMALLINT, "column_index" INTEGER, "dbname" VARCHAR, PRIMARY KEY("table_name","column_name"));
-CREATE TABLE "TAP_SCHEMA"."keys" ("key_id" VARCHAR, "from_table" VARCHAR, "target_table" VARCHAR, "description" VARCHAR, "utype" VARCHAR, PRIMARY KEY("key_id"));
-CREATE TABLE "TAP_SCHEMA"."key_columns" ("key_id" VARCHAR, "from_column" VARCHAR, "target_column" VARCHAR, PRIMARY KEY("key_id"));
+CREATE TABLE IF NOT EXISTS "TAP_SCHEMA"."schemas" ("schema_name" VARCHAR, "description" VARCHAR, "utype" VARCHAR, "schema_index" INTEGER, "dbname" VARCHAR, PRIMARY KEY("schema_name"));
+CREATE TABLE IF NOT EXISTS "TAP_SCHEMA"."tables" ("schema_name" VARCHAR, "table_name" VARCHAR, "table_type" VARCHAR, "description" VARCHAR, "utype" VARCHAR, "dbname" VARCHAR, "table_index" INTEGER, PRIMARY KEY("table_name"));
+CREATE TABLE IF NOT EXISTS "TAP_SCHEMA"."columns" ("table_name" VARCHAR, "column_name" VARCHAR, "description" VARCHAR, "unit" VARCHAR, "ucd" VARCHAR, "utype" VARCHAR, "xtype" VARCHAR, "datatype" VARCHAR, "size" INTEGER, "arraysize" VARCHAR, "principal" SMALLINT, "indexed" SMALLINT, "std" SMALLINT, "column_index" INTEGER, "dbname" VARCHAR, PRIMARY KEY("table_name","column_name"));
+CREATE TABLE IF NOT EXISTS "TAP_SCHEMA"."keys" ("key_id" VARCHAR, "from_table" VARCHAR, "target_table" VARCHAR, "description" VARCHAR, "utype" VARCHAR, PRIMARY KEY("key_id"));
+CREATE TABLE IF NOT EXISTS "TAP_SCHEMA"."key_columns" ("key_id" VARCHAR, "from_column" VARCHAR, "target_column" VARCHAR, PRIMARY KEY("key_id"));
 
 /**
   Add self-describing metadata for the TAP_SCHEMA and its contents.
  */
-INSERT INTO "TAP_SCHEMA"."schemas" VALUES ('TAP_SCHEMA', 'Set of tables listing and describing the schemas, tables and columns published in this TAP service.', NULL, NULL);
+INSERT INTO "TAP_SCHEMA"."schemas" VALUES ('TAP_SCHEMA', 'Set of tables listing and describing the schemas, tables and columns published in this TAP service.', NULL, NULL) ON CONFLICT ("schema_name") DO NOTHING;
 
-INSERT INTO "TAP_SCHEMA"."tables" VALUES ('TAP_SCHEMA', 'TAP_SCHEMA.schemas', 'table', 'List of schemas published in this TAP service.', NULL, NULL);
-INSERT INTO "TAP_SCHEMA"."tables" VALUES ('TAP_SCHEMA', 'TAP_SCHEMA.tables', 'table', 'List of tables published in this TAP service.', NULL, NULL);
-INSERT INTO "TAP_SCHEMA"."tables" VALUES ('TAP_SCHEMA', 'TAP_SCHEMA.columns', 'table', 'List of columns of all tables listed in TAP_SCHEMA.TABLES and published in this TAP service.', NULL, NULL);
-INSERT INTO "TAP_SCHEMA"."tables" VALUES ('TAP_SCHEMA', 'TAP_SCHEMA.keys', 'table', 'List all foreign keys but provides just the tables linked by the foreign key. To know which columns of these tables are linked, see in TAP_SCHEMA.key_columns using the key_id.', NULL, NULL);
-INSERT INTO "TAP_SCHEMA"."tables" VALUES ('TAP_SCHEMA', 'TAP_SCHEMA.key_columns', 'table', 'List all foreign keys but provides just the columns linked by the foreign key. To know the table of these columns, see in TAP_SCHEMA.keys using the key_id.', NULL, NULL);
+INSERT INTO "TAP_SCHEMA"."tables" ("schema_name", "table_name", "table_type", "description", "utype", "dbname")
+SELECT 'TAP_SCHEMA', 'TAP_SCHEMA.schemas', 'table', 'List of schemas published in this TAP service.', NULL, NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM "TAP_SCHEMA"."tables"
+    WHERE "schema_name" = 'TAP_SCHEMA'
+      AND "table_name" = 'TAP_SCHEMA.schemas'
+);
 
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.schemas', 'schema_name', 'schema name, possibly qualified', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 1, 1, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.schemas', 'description', 'brief description of schema', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.schemas', 'utype', 'UTYPE if schema corresponds to a data model', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.schemas', 'schema_index', 'To allow ordered display if required.', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'schema_name', 'the schema name from TAP_SCHEMA.schemas', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 1, 1, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'table_name', 'table name as it should be used in queries', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 1, 1, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'table_type', 'one of: table, view', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'description', 'brief description of table', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'utype', 'UTYPE if table corresponds to a data model', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'table_index', 'To allow ordered display if required.', NULL, NULL, NULL, NULL,'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'table_name', 'table name from TAP_SCHEMA.tables', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0,1, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'column_name', 'column name', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 1, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'description', 'brief description of column', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'unit', 'unit in VO standard format', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'ucd', 'UCD of column if any', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'utype', 'UTYPE of column if any', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'datatype', 'ADQL datatype as in section 2.5', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', '"size"', 'length of variable length datatypes', NULL, NULL, NULL, NULL, 'INTEGER', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'arraysize', 'arraysize, * for varying or NULL for none', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'xtype', 'custom type specification, consider utype instead', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'principal', 'a principal column; 1 means true, 0 means false', NULL, NULL, NULL, NULL, 'INTEGER', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'indexed', 'an indexed column; 1 means true, 0 means false', NULL, NULL, NULL, NULL, 'INTEGER', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'std', 'a standard column; 1 means true, 0 means false', NULL, NULL, NULL, NULL, 'INTEGER', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'column_index', 'To allow ordered display if required.', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.keys', 'key_id', 'unique key identifier', NULL, NULL, NULL, NULL,'VARCHAR', -1, 1, 1, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.keys', 'from_table', 'fully qualified table name', NULL, NULL, NULL, NULL,'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.keys', 'target_table', 'fully qualified table name', NULL, NULL, NULL, NULL,'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.keys', 'description', 'description of this key', NULL, NULL, NULL, NULL,'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.keys', 'utype', 'utype of this key', NULL, NULL, NULL, NULL,'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.key_columns', 'key_id', 'unique key identifier', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 1, 1, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.key_columns', 'from_column', 'key column name in the from_table', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
-INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.key_columns', 'target_column', 'key column name in the target_table', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1);
+INSERT INTO "TAP_SCHEMA"."tables" ("schema_name", "table_name", "table_type", "description", "utype", "dbname")
+SELECT 'TAP_SCHEMA', 'TAP_SCHEMA.tables', 'table', 'List of tables published in this TAP service.', NULL, NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM "TAP_SCHEMA"."tables"
+    WHERE "schema_name" = 'TAP_SCHEMA'
+      AND "table_name" = 'TAP_SCHEMA.schemas'
+);
+
+INSERT INTO "TAP_SCHEMA"."tables" ("schema_name", "table_name", "table_type", "description", "utype", "dbname")
+SELECT 'TAP_SCHEMA', 'TAP_SCHEMA.columns', 'table', 'List of columns of all tables listed in TAP_SCHEMA.TABLES and published in this TAP service.', NULL, NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM "TAP_SCHEMA"."tables"
+    WHERE "schema_name" = 'TAP_SCHEMA'
+  AND "table_name" = 'TAP_SCHEMA.schemas'
+);
+
+INSERT INTO "TAP_SCHEMA"."tables" ("schema_name", "table_name", "table_type", "description", "utype", "dbname")
+SELECT 'TAP_SCHEMA', 'TAP_SCHEMA.keys', 'table', 'List all foreign keys but provides just the tables linked by the foreign key. To know which columns of these tables are linked, see in TAP_SCHEMA.key_columns using the key_id.', NULL, NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM "TAP_SCHEMA"."tables"
+    WHERE "schema_name" = 'TAP_SCHEMA'
+  AND "table_name" = 'TAP_SCHEMA.schemas'
+);
+
+INSERT INTO "TAP_SCHEMA"."tables" ("schema_name", "table_name", "table_type", "description", "utype", "dbname")
+SELECT 'TAP_SCHEMA', 'TAP_SCHEMA.key_columns', 'table', 'List all foreign keys but provides just the columns linked by the foreign key. To know the table of these columns, see in TAP_SCHEMA.keys using the key_id.', NULL, NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM "TAP_SCHEMA"."tables"
+    WHERE "schema_name" = 'TAP_SCHEMA'
+      AND "table_name" = 'TAP_SCHEMA.schemas'
+);
+
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.schemas', 'schema_name', 'schema name, possibly qualified', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 1, 1, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.schemas', 'description', 'brief description of schema', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.schemas', 'utype', 'UTYPE if schema corresponds to a data model', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.schemas', 'schema_index', 'To allow ordered display if required.', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'schema_name', 'the schema name from TAP_SCHEMA.schemas', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 1, 1, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'table_name', 'table name as it should be used in queries', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 1, 1, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'table_type', 'one of: table, view', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'description', 'brief description of table', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'utype', 'UTYPE if table corresponds to a data model', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.tables', 'table_index', 'To allow ordered display if required.', NULL, NULL, NULL, NULL,'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'table_name', 'table name from TAP_SCHEMA.tables', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0,1, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'column_name', 'column name', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 1, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'description', 'brief description of column', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'unit', 'unit in VO standard format', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'ucd', 'UCD of column if any', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'utype', 'UTYPE of column if any', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'datatype', 'ADQL datatype as in section 2.5', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', '"size"', 'length of variable length datatypes', NULL, NULL, NULL, NULL, 'INTEGER', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'arraysize', 'arraysize, * for varying or NULL for none', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'xtype', 'custom type specification, consider utype instead', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'principal', 'a principal column; 1 means true, 0 means false', NULL, NULL, NULL, NULL, 'INTEGER', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'indexed', 'an indexed column; 1 means true, 0 means false', NULL, NULL, NULL, NULL, 'INTEGER', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'std', 'a standard column; 1 means true, 0 means false', NULL, NULL, NULL, NULL, 'INTEGER', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.columns', 'column_index', 'To allow ordered display if required.', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.keys', 'key_id', 'unique key identifier', NULL, NULL, NULL, NULL,'VARCHAR', -1, 1, 1, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.keys', 'from_table', 'fully qualified table name', NULL, NULL, NULL, NULL,'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.keys', 'target_table', 'fully qualified table name', NULL, NULL, NULL, NULL,'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.keys', 'description', 'description of this key', NULL, NULL, NULL, NULL,'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.keys', 'utype', 'utype of this key', NULL, NULL, NULL, NULL,'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.key_columns', 'key_id', 'unique key identifier', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 1, 1, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.key_columns', 'from_column', 'key column name in the from_table', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
+INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.key_columns', 'target_column', 'key column name in the target_table', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 0, 0, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;
 
 /* ************************************* */
 /* ADDITION OF ALL THE OBJECT TO PUBLISH */
 /* ************************************* */
-INSERT INTO "TAP_SCHEMA"."schemas"(schema_name) VALUES ('public');
+INSERT INTO "TAP_SCHEMA"."schemas"(schema_name) VALUES ('public') ON CONFLICT (schema_name) DO NOTHING;
 
 /*
  TAPLint complains about ObsPlan being missing, but it's not required unless we are storing planning data. Left here if required at a later date (retrieved from a GAIA service I think)

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -38,7 +38,7 @@ SELECT 'TAP_SCHEMA', 'TAP_SCHEMA.tables', 'table', 'List of tables published in 
 WHERE NOT EXISTS (
     SELECT 1 FROM "TAP_SCHEMA"."tables"
     WHERE "schema_name" = 'TAP_SCHEMA'
-      AND "table_name" = 'TAP_SCHEMA.schemas'
+      AND "table_name" = 'TAP_SCHEMA.tables'
 );
 
 INSERT INTO "TAP_SCHEMA"."tables" ("schema_name", "table_name", "table_type", "description", "utype", "dbname")
@@ -46,7 +46,7 @@ SELECT 'TAP_SCHEMA', 'TAP_SCHEMA.columns', 'table', 'List of columns of all tabl
 WHERE NOT EXISTS (
     SELECT 1 FROM "TAP_SCHEMA"."tables"
     WHERE "schema_name" = 'TAP_SCHEMA'
-  AND "table_name" = 'TAP_SCHEMA.schemas'
+  AND "table_name" = 'TAP_SCHEMA.columns'
 );
 
 INSERT INTO "TAP_SCHEMA"."tables" ("schema_name", "table_name", "table_type", "description", "utype", "dbname")
@@ -54,7 +54,7 @@ SELECT 'TAP_SCHEMA', 'TAP_SCHEMA.keys', 'table', 'List all foreign keys but prov
 WHERE NOT EXISTS (
     SELECT 1 FROM "TAP_SCHEMA"."tables"
     WHERE "schema_name" = 'TAP_SCHEMA'
-  AND "table_name" = 'TAP_SCHEMA.schemas'
+  AND "table_name" = 'TAP_SCHEMA.keys'
 );
 
 INSERT INTO "TAP_SCHEMA"."tables" ("schema_name", "table_name", "table_type", "description", "utype", "dbname")
@@ -62,7 +62,7 @@ SELECT 'TAP_SCHEMA', 'TAP_SCHEMA.key_columns', 'table', 'List all foreign keys b
 WHERE NOT EXISTS (
     SELECT 1 FROM "TAP_SCHEMA"."tables"
     WHERE "schema_name" = 'TAP_SCHEMA'
-      AND "table_name" = 'TAP_SCHEMA.schemas'
+      AND "table_name" = 'TAP_SCHEMA.key_columns'
 );
 
 INSERT INTO "TAP_SCHEMA"."columns" VALUES ('TAP_SCHEMA.schemas', 'schema_name', 'schema name, possibly qualified', NULL, NULL, NULL, NULL, 'VARCHAR', -1, 1, 1, 1, 1) ON CONFLICT ("table_name", "column_name") DO NOTHING;


### PR DESCRIPTION
Resolved the issues with the import.sql (& java bean that adds Observation etc. to the TAP_SCHEMA) attempting to re-add existing entities to the database when re-deploying the application.

Made the individual GET operations return uniform XML casing (lists were pascal & individual were camel, both pascal now).

More descriptive text response when attempting to delete an observation with an empty string (observationId).

Updated the detail.md to conform with the small changes to the CAOM library.
